### PR TITLE
Fixing PATCH bug

### DIFF
--- a/chrome/js/requester.js
+++ b/chrome/js/requester.js
@@ -464,7 +464,7 @@ postman.currentRequest = {
     dataMode:"params",
     isFromCollection: false,
     collectionRequestId: "",
-    methodsWithBody:["post", "put", "patch", "delete"],
+    methodsWithBody:["POST", "PUT", "PATCH", "DELETE"],
     areListenersAdded:false,
     startTime:0,
     endTime:0,
@@ -1467,7 +1467,7 @@ postman.currentRequest = {
         postman.currentRequest.xhr = xhr;
 
         var url = this.url;
-        var method = this.method;
+        var method = this.method.toUpperCase();
         var data = this.body.data;
         var originalData = data;
         var finalBodyData;


### PR DESCRIPTION
Changing send method to upper case all HTTP methods. Chrome xhr does not do this for methods like PATCH. This causes most servers to throw "Method not Implemented". Not sure if you want/need to toUpper other methods around the code like get. I already did this for methodsWithBody. I believe this is what issue #28 was complaining about.
