### PR TITLE
Removed second parameter sent to indexedDB.open()

### DIFF
--- a/chrome/js/requester.js
+++ b/chrome/js/requester.js
@@ -3064,7 +3064,7 @@ pm.indexedDB = {
     open_v21:function () {
         console.log("Open v21");
 
-        var request = indexedDB.open("postman", "POSTman request history");
+        var request = indexedDB.open("postman");
         request.onsuccess = function (e) {
             var v = "0.47";
             pm.indexedDB.db = e.target.result;


### PR DESCRIPTION
This line was throwing `Uncaught TypeError: Type error` which essentially prevented Postman from working in Chrome 23.0.1262.0 dev. Removing `, "POSTman request history"` resolved the issue.
