### PR TITLE
Chrome v23+ should open_latest() not open_v21()

### DIFF
--- a/chrome/js/requester.js
+++ b/chrome/js/requester.js
@@ -3248,7 +3248,7 @@ pm.indexedDB = {
     },
 
     open:function () {
-        if (parseInt(navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./)[2]) <= 23) {
+        if (Math.floor(navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./)[2]) < 23) {
             pm.indexedDB.open_v21();
         }
         else {


### PR DESCRIPTION
Changed the `open` logic to A) check for `<` instead of `<=` v23.  
And B) use Math.floor() instead of parseInt(): [jsperf](http://jsperf.com/math-floor-vs-math-round-vs-parseint/55)
