### PR TITLE
Allow undefined http response codes without breaking the app

### DIFF
--- a/chrome/js/requester.js
+++ b/chrome/js/requester.js
@@ -4381,13 +4381,17 @@ pm.request = {
                     responseCodeName = response.statusText;
                 }
                 else {
-                    responseCodeName = httpStatusCodes[response.status]['name'];
+                    if(httpStatusCodes[response.status]) {
+                        responseCodeName = httpStatusCodes[response.status]['name'];
+                    } else {
+                        responseCodeName = 'Not defined';
+                    }
                 }
 
                 var responseCode = {
                     'code':response.status,
                     'name':responseCodeName,
-                    'detail':httpStatusCodes[response.status]['detail']
+                    'detail':httpStatusCodes[response.status] ? httpStatusCodes[response.status]['detail'] : 'No detail defined'
                 };
 
                 var responseData;


### PR DESCRIPTION
While testing an internal api I use at work one of the responses returned an http response code that was not defined in `js/httpstatuscodes.js` and so threw and error and broke the whole app. This pull request is just to check whether the status code is defined before trying to access its attributes. The default detail and name could probably be improved but it works!

Thanks for the great app, it's awesome! 
