### PR TITLE
Fix addRequest when request history is full

### DIFF
--- a/chrome/js/requester.js
+++ b/chrome/js/requester.js
@@ -2084,7 +2084,7 @@ pm.history = {
 
         if (requestsCount >= maxHistoryCount) {
             //Delete the last request
-            var lastRequest = requests[requestsCount - 1];
+            var lastRequest = requests[0];
             this.deleteRequest(lastRequest.id);
         }
 


### PR DESCRIPTION
The request history is added by pushing to the end of the array, when it is full it needs to delete the oldest one.  It was incorrectly deleting from the end of the array, it should delete from the beginning.

Thanks,

Eric
