### PR TITLE
Fix request history with form data

### DIFF
--- a/chrome/js/modules/request.js
+++ b/chrome/js/modules/request.js
@@ -1765,7 +1765,7 @@ pm.request = {
         }
 
         if (pm.settings.get("autoSaveRequest")) {
-            pm.history.addRequest(originalUrl, method, pm.request.getPackedHeaders(), originalData, this.dataMode);
+            pm.history.addRequest(originalUrl, method, pm.request.getPackedHeaders(), pm.request.body.getData(), this.dataMode);
         }
 
         $('#submit-request').button("loading");

--- a/chrome/js/requester.js
+++ b/chrome/js/requester.js
@@ -5283,7 +5283,7 @@ pm.request = {
         }
 
         if (pm.settings.get("autoSaveRequest")) {
-            pm.history.addRequest(originalUrl, method, pm.request.getPackedHeaders(), originalData, this.dataMode);
+            pm.history.addRequest(originalUrl, method, pm.request.getPackedHeaders(), pm.request.body.getData(), this.dataMode);
         }
 
         $('#submit-request').button("loading");


### PR DESCRIPTION
Request history was saving raw data, prior to environment variable processing.  For form requests this would not preserve the request data.  This change likewise gets the data without environment variable processing regardless of the type.

Thanks again,

Eric
