### PR TITLE
Wrap error url in an <a> tag

### DIFF
--- a/chrome/js/requester.js
+++ b/chrome/js/requester.js
@@ -4464,7 +4464,7 @@ pm.request = {
                 //Something went wrong
                 if (response.status == 0) {
                     var errorUrl = pm.envManager.convertString(pm.request.url);
-                    $('#connection-error-url').html(errorUrl);
+                    $('#connection-error-url').html("<a href='" + errorUrl + "' target='_blank'>" + errorUrl + "</a>");
                     pm.request.response.showScreen("failed");
                     $('#submit-request').button("reset");
                     return false;


### PR DESCRIPTION
For example when the request fails because of an untrusted certificate,
the error url can be clicked to open the request in a new tab and confirm the security exception
