### PR TITLE
Add COPY method to selector

### DIFF
--- a/chrome/index.html
+++ b/chrome/index.html
@@ -404,6 +404,7 @@
                         <option value="PUT">PUT</option>
                         <option value="PATCH">PATCH</option>
                         <option value="DELETE">DELETE</option>
+                        <option value="COPY">COPY</option>
                         <option value="HEAD">HEAD</option>
                         <option value="OPTIONS">OPTIONS</option>                            
                         <option value="LINK">LINK</option>


### PR DESCRIPTION
I always add this by using the Developer Tools of Chrome right now to test copying of a ressource. Please release me from this curse.
