### PR TITLE
remove default realm so we can use empty realms

### DIFF
--- a/chrome/js/modules/helpers.js
+++ b/chrome/js/modules/helpers.js
@@ -243,12 +243,7 @@ pm.helpers = {
 
             var realm = $('#request-helper-oauth1-realm').val();
 
-            if (realm === '') {
-                processedUrl = pm.envManager.convertString($('#url').val()).trim();
-            }
-            else {
-                processedUrl = pm.envManager.convertString(realm);
-            }
+            processedUrl = pm.envManager.convertString(realm);
 
             processedUrl = ensureProperUrl(processedUrl);
 


### PR DESCRIPTION
right now there is no way in the UI to support an empty realm because the uri is used to generate a default realm.  no where in the oauth specifications does it say a realm should default to any specific value and it does explicitly say realms are optional.

http://tools.ietf.org/html/rfc2617#section-1.2
http://tools.ietf.org/html/rfc5849#section-3.5.1
