### PR TITLE
Don't crash if a custom/non-standard HTTP status code is encountered

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .idea/
+*.iml
 node_modules/
 design/
 screenshots/

--- a/chrome/js/modules/request.js
+++ b/chrome/js/modules/request.js
@@ -946,13 +946,13 @@ pm.request = {
                     responseCodeName = response.statusText;
                 }
                 else {
-                    responseCodeName = httpStatusCodes[response.status]['name'];
+                    responseCodeName = httpStatusCodes[response.status] ? httpStatusCodes[response.status]['name'] : "";
                 }
 
                 var responseCode = {
                     'code':response.status,
                     'name':responseCodeName,
-                    'detail':httpStatusCodes[response.status]['detail']
+                    'detail':httpStatusCodes[response.status] ? httpStatusCodes[response.status]['detail'] : ""
                 };
 
                 var responseData;


### PR DESCRIPTION
When using POSTMan with an API that uses custom (non-standard) HTTP status code (which is completely legal according to [RFC2616](http://tools.ietf.org/html/rfc2616#section-6.1.1)) the extension currently tries to access an undefined field when creating the `responseCode`:

```
'detail':httpStatusCodes[response.status]['detail']
```

Since `httpStatusCodes` only contains standard codes, the request for `detail` causes an error (can't access a property on `undefined`). This PR tries to fix this.

I also added `*.iml` to `.gitignore`, since this is the other format used by IDEA for project files which is already featured in the file with `.idea`.
