### PR TITLE
Check state of 'request-meta-actions-togglesize' and build accordingly

### DIFF
--- a/chrome/js/modules/request.js
+++ b/chrome/js/modules/request.js
@@ -1538,8 +1538,8 @@ pm.request = {
             //Disabling this. Will enable after resolving indexedDB issues
             //$('#response-sample-save-start-container').css("display", "inline-block");
 
-            $('.request-meta-actions-togglesize').attr('data-action', 'minimize');
-            $('.request-meta-actions-togglesize img').attr('src', 'img/circle_minus.png');
+            $('.request-meta-actions-togglesize').attr('data-action', ($('.request-meta-actions-togglesize').attr('data-action') == 'minimize' ? 'minimize' : 'maximize'));
+            $('.request-meta-actions-togglesize img').attr('src', ($('.request-meta-actions-togglesize').attr('data-action') == 'minimize' ? 'img/circle_minus.png' : 'img/circle_plus.png'));
 
             //Load sample
             if ("responses" in request) {


### PR DESCRIPTION
## Summary

When hiding a request description and changing requests the toggle state of the `circle_minus.png`/`circle_plus.png` loses state and requires an extra click to show the request description.
## To Reproduce
1. Load a collection
2. Select a request
3. Hover next to the request name to reveal the `circle_minus.png` icon
4. Click `circle_minus.png` to hide the request description. Note that the `circle_minus.png` icon changes to `circle_plus.png` and `.request-meta-actions-togglesize`'s `data-action` changes from `minimize` to `maximize`
5. Select another request. Note that the `circle_plus.png` icon changes back to `circle_minus.png` and  `.request-meta-actions-togglesize`'s `data-action` changes from `maximize` to `minimize`
## Fix

The fix is simply to check the state of `.request-meta-actions-togglesize`'s `data-action` when building out that part of the page.
## Donation

BTW [I contacted you a while back on twitter about donating via bitcoin](https://twitter.com/cgcardona/status/468193983051489280) and just wanted to follow up on that and remind you to create a bitcoin address so I can donate.

Thanks for an amazing resource!

:+1: 
