### PR TITLE
[GH-678] OAuth: Don't re-encode url parameters

### DIFF
--- a/chrome/js/dropbox/oauth.js
+++ b/chrome/js/dropbox/oauth.js
@@ -467,7 +467,7 @@ OAuth.setProperties(OAuth.SignatureMethod, // class members
         }
         return OAuth.percentEncode(message.method.toUpperCase())
          +'&'+ OAuth.percentEncode(OAuth.SignatureMethod.normalizeUrl(URL))
-         +'&'+ OAuth.percentEncode(OAuth.SignatureMethod.normalizeParameters(parameters));
+         +'&'+ OAuth.SignatureMethod.normalizeParameters(parameters);
     }
 ,
     normalizeUrl: function normalizeUrl(url) {


### PR DESCRIPTION
Should fix GH-678
