### PR TITLE
Added new check box to oauth 1.0 settings to keep empty parameters (namely

### DIFF
--- a/chrome/index.html
+++ b/chrome/index.html
@@ -357,6 +357,13 @@
                         </div>
 
                         <div class="control-group">
+                            <label class="control-label">Keep empty parameters</label>
+                            <div class="controls">
+                                <input type="checkbox" class="checkbox" id="request-helper-keep-empty-parameters"/>
+                            </div>
+                        </div>
+
+                        <div class="control-group">
                             <div class="controls">
                                 <a class="btn btn-secondary request-helper-submit"
                                    data-type="oAuth1">

--- a/chrome/js/modules/helpers.js
+++ b/chrome/js/modules/helpers.js
@@ -264,7 +264,7 @@ pm.helpers = {
 
             //all the fields defined by oauth
             $('input.signatureParam').each(function () {
-                if ($(this).val() != '') {
+                if ($(this).val() != '' || $('#request-helper-keep-empty-parameters').attr('checked')) {
                     var val = $(this).val();
                     val = pm.envManager.convertString(val);
                     message.parameters.push([$(this).attr('key'), val]);
@@ -352,7 +352,7 @@ pm.helpers = {
             var signatureKey = "oauth_signature";
 
             $('input.signatureParam').each(function () {
-                if ($(this).val() != '') {
+                if ($(this).val() != '' || $('#request-helper-keep-empty-parameters').attr('checked')) {
                     var val = $(this).val();
                     params.push({key: $(this).attr('key'), value: val});
                 }

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,6 +1,6 @@
 {
     "name":"__MSG_name__",
-    "version":"0.8.4.10",
+    "version":"0.8.4.11",
     "icons":{
         "16":"icon_16.png",
         "32":"icon_32.png",


### PR DESCRIPTION
oauth-token) in both the header and the generated signature.  This enables
functionality with strict complient oauth 1.0 clients.
@ericfode @silvermy @autodesk
