### PR TITLE
Make value field larger and proportional to size

### DIFF
--- a/chrome/css/keyvalueeditor.css
+++ b/chrome/css/keyvalueeditor.css
@@ -9,7 +9,16 @@
     border-radius: 0 !important;
     outline: none !important;
     margin-right: 10px !important;
-    width: 224px !important;
+}
+
+.keyvalueeditor-key
+{
+    width: 10% !important;
+}
+
+.keyvalueeditor-value
+{
+    width: 80% !important;
 }
 
 .keyvalueeditor-value-file {


### PR DESCRIPTION
Hi there. While I was working with a server that does SOLR queries with long parameter values, I found the "value" fields in the parameters too small to be useful, so I fixed them to be proportional to the size of the area they are in.
