### PR TITLE
Update the bug_report template 

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -22,7 +22,7 @@ Steps to reproduce the behavior:
 A clear and concise description of what you expected to happen.
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem. Make sure the screenshot does not contain any API keys or access tokens. 
+If applicable, add screenshots to help explain your problem. Please make sure the screenshot does not contain any API keys or access tokens. 
 
 **App information (please complete the following information):**
  - App Type [e.g. Chrome App, Native App]

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -22,7 +22,7 @@ Steps to reproduce the behavior:
 A clear and concise description of what you expected to happen.
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem. Please make sure the screenshot does not contain any API keys or access tokens. 
+If applicable, add screenshots to help explain your problem. Please make sure the screenshot does not contain any sensitive information such as API keys or access tokens. 
 
 **App information (please complete the following information):**
  - App Type [e.g. Chrome App, Native App]

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -22,7 +22,7 @@ Steps to reproduce the behavior:
 A clear and concise description of what you expected to happen.
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
+If applicable, add screenshots to help explain your problem. Make sure the screenshot does not contain any API keys or access tokens. 
 
 **App information (please complete the following information):**
  - App Type [e.g. Chrome App, Native App]


### PR DESCRIPTION
We've seen a few cases in the past where the user accidentally leaked an access token or API key while reporting an issue. This puts the user at risk for an account take over or information disclosure. 

If we add the following line in our bug report template, we might prevent such leaks. 

`Please make sure the screenshot does not contain any API keys or access tokens.` 