### PR TITLE
Add release notes for app 7.29

### DIFF
--- a/release-notes/app-7.29.md
+++ b/release-notes/app-7.29.md
@@ -8,9 +8,8 @@ Here’s what you can find in this Postman release:
 
 ### Improvements
 
-* No more orphaned API elements. If an element - collection, API, environment, etc. - is only in a single workspace it can no longer be removed from that workspace
+* A collection or environment that exists only in a single workspace, cannot be removed, but only deleted or shared
 [#4509](https://github.com/postmanlabs/postman-app-support/issues/4509)
-* When using the workspace switcher, users with only an Admin or Billing role will see more helpful information letting them know how to join a workspace.
 * When using the workspace switcher, you can now use your keyboard’s arrow keys to navigate between the menu options.
 * When importing an OpenAPI specification, there is now support for parameter serialization.
 

--- a/release-notes/app-7.29.md
+++ b/release-notes/app-7.29.md
@@ -1,0 +1,29 @@
+## Postman v7.29.0
+
+Here’s what you can find in this Postman release:
+
+* When writing pre-request and test scripts, global pm.* functions, Node.js, and other Node modules from the Postman Sandbox will now appear in the autocomplete menu.
+* When authoring requests, you can now insert an `$isoTimestamp` variable from our library of dynamic variables.
+* You can now automatically validate your OpenAPI 3.0 specification while importing or editing it. 
+
+### Improvements
+
+* No more orphaned API elements. If an element - collection, API, environment, etc. - is only in a single workspace it can no longer be removed from that workspace
+[#4509](https://github.com/postmanlabs/postman-app-support/issues/4509)
+* When using the workspace switcher, users with only an Admin or Billing role will see more helpful information letting them know how to join a workspace.
+* When using the workspace switcher, you can now use your keyboard’s arrow keys to navigate between the menu options.
+* When importing an OpenAPI specification, there is now support for parameter serialization.
+
+### Bug Fixes
+
+* Fixed a bug where after sending a request and opening a new tab, the tab for the previous request would be replaced by the new request tab
+[#6992](https://github.com/postmanlabs/postman-app-support/issues/6992)
+* Fixed a bug where duplicating a collection, folder, request, or environment twice would give the same name to the duplicated entities
+[#8012](https://github.com/postmanlabs/postman-app-support/issues/8012)
+* Fixed a bug where examples response pane was not visible for small window height
+[#8797](https://github.com/postmanlabs/postman-app-support/issues/8797)
+* Fixed error state in share entity modal when the entity is not synced or deleted
+[#8676](https://github.com/postmanlabs/postman-app-support/issues/8676)
+* Fixed a bug when sharing an API element where zooming in would hide the action buttons
+[#8691](https://github.com/postmanlabs/postman-app-support/issues/8691)
+* Fixed a bug where after leaving a private team workspace, the workspace switcher would remain in a loading state.


### PR DESCRIPTION
We've just released version 7.29 of the Postman app! Update your app or get the latest version here: https://www.postman.com/downloads/ 🚀

Improvement(s)
Closes #4509

Bug Fixe(s):
Fixes #6992
Fixes #8012
Fixes #8797
Fixes #8676
Fixes #8691

See the release notes attached to that Pull Request for the full details!