### PR TITLE
Created a new config.yml file

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security Vulnerability
+    url: https://github.com/postmanlabs/postman-app-support/security/policy
+    about: Read our security policy and report vulnerabilities
+  - name: Postman Learning Center
+    url: https://learning.postman.com
+    about: Learn how to use Postman in our Learning Center 
+  - name: Postman Community Forum
+    url: https://community.postman.com
+    about: Get support and connect to the community on our forum


### PR DESCRIPTION
- Contains external links out to our Documentation in the Learning Center and also the Community site
- Additional entry to link out the security policy page, the Security template would need to be deleted as this would duplicate the link
- This change also removes the link in the `New Issue` page that allowed users to create a blank issue.