### PR TITLE
Add release notes for app 7.36

### DIFF
--- a/release-notes/app-7.36.md
+++ b/release-notes/app-7.36.md
@@ -1,15 +1,24 @@
 ## Postman v7.36.0
 
 ### What's New
-* Postman now supports generating code snippets in Dart. 
+* Postman now supports generating code snippets in Dart
 [#231](https://github.com/postmanlabs/postman-code-generators/issues/231)
 
 ### Bug Fixes
 * Fixed an issue where users couldn't generate collection for certain kinds of GraphQL schemas
 [#8863](https://github.com/postmanlabs/postman-app-support/issues/8863)
-* Fixed an issue when importing files. where users were not able to drag and drop files and folders. 
+* Fixed an issue where column width wouldn't resize for system-generated Headers
+[#8918](https://github.com/postmanlabs/postman-app-support/issues/8918)
+* Fixed an issue when importing files, where users were not able to drag and drop files and folders
 [#9135](https://github.com/postmanlabs/postman-app-support/issues/9135)
-* Fixed an issue when importing from GitHub where trying to import from an empty repository would cause an error. 
+* Fixed an issue when importing from GitHub, where trying to import from an empty repository would cause an error
 [#9144](https://github.com/postmanlabs/postman-app-support/issues/9144)
-* Fixed an issue in the response viewer, where changes made to indentation settings change weren’t reflected. 
+* Fixed an issue in the response viewer, where changes made to indentation settings change weren’t reflected
 [#9209](https://github.com/postmanlabs/postman-app-support/issues/9209)
+* Fixed an issue where changing access token value for one tab was updating the value for another tab instead
+[#9218](https://github.com/postmanlabs/postman-app-support/issues/9218),
+[#9238](https://github.com/postmanlabs/postman-app-support/issues/9238),
+[#9246](https://github.com/postmanlabs/postman-app-support/issues/9246),
+[#9262](https://github.com/postmanlabs/postman-app-support/issues/9262)
+* Fixed an issue where users' existing OAuth2 settings seemed to disappear.
+* Fixed an issue where Action Menu can change URL in Comment Mode.

--- a/release-notes/app-7.36.md
+++ b/release-notes/app-7.36.md
@@ -1,0 +1,15 @@
+## Postman v7.36.0
+
+### What's New
+* Postman now supports generating code snippets in Dart. 
+[#231](https://github.com/postmanlabs/postman-code-generators/issues/231)
+
+### Bug Fixes
+* Fixed an issue where users couldn't generate collection for certain kinds of GraphQL schemas
+[#8863](https://github.com/postmanlabs/postman-app-support/issues/8863)
+* Fixed an issue when importing files. where users were not able to drag and drop files and folders. 
+[#9135](https://github.com/postmanlabs/postman-app-support/issues/9135)
+* Fixed an issue when importing from GitHub where trying to import from an empty repository would cause an error. 
+[#9144](https://github.com/postmanlabs/postman-app-support/issues/9144)
+* Fixed an issue in the response viewer, where changes made to indentation settings change weren’t reflected. 
+[#9209](https://github.com/postmanlabs/postman-app-support/issues/9209)


### PR DESCRIPTION
We've just released version 7.36 of the Postman app! Update your app or get the latest version here: https://www.postman.com/downloads/ 🚀

### What's New
* Postman now supports generating code snippets in Dart
[#231](https://github.com/postmanlabs/postman-code-generators/issues/231)

### Bug Fixes
* Fixed an issue where users couldn't generate collection for certain kinds of GraphQL schemas - fixes [#8863](https://github.com/postmanlabs/postman-app-support/issues/8863)
* Fixed an issue where column width wouldn't resize for system-generated Headers - fixes [#8918](https://github.com/postmanlabs/postman-app-support/issues/8918)
* Fixed an issue when importing files, where users were not able to drag and drop files and folders - fixes [#9135](https://github.com/postmanlabs/postman-app-support/issues/9135)
* Fixed an issue when importing from GitHub, where trying to import from an empty repository would cause an error - fixes [#9144](https://github.com/postmanlabs/postman-app-support/issues/9144)
* Fixed an issue in the response viewer, where changes made to indentation settings change weren’t reflected - fixes [#9209](https://github.com/postmanlabs/postman-app-support/issues/9209)
* Fixed an issue where changing access token value for one tab was updating the value for another tab instead - 
fixes [#9218](https://github.com/postmanlabs/postman-app-support/issues/9218),
fixes [#9238](https://github.com/postmanlabs/postman-app-support/issues/9238),
fixes [#9246](https://github.com/postmanlabs/postman-app-support/issues/9246),
fixes [#9262](https://github.com/postmanlabs/postman-app-support/issues/9262)
* Fixed an issue where users' existing OAuth2 settings seemed to disappear.
* Fixed an issue where Action Menu can change URL in Comment Mode.