### PR TITLE
Add release notes 7.36.1

### DIFF
--- a/release-notes/app-7.36.1.md
+++ b/release-notes/app-7.36.1.md
@@ -1,0 +1,8 @@
+## Postman v7.36.1
+
+### Bug Fixes
+* Fixed an issue when exporting collections, where the script and variable IDs were included in the collection JSON file. Now they are stripped from the export
+[#2906](https://github.com/postmanlabs/postman-app-support/issues/2906), 
+[#4802](https://github.com/postmanlabs/postman-app-support/issues/4802)
+* Fixed an issue where importing invalid swagger was not giving any feedback
+[#9315](https://github.com/postmanlabs/postman-app-support/issues/9315)


### PR DESCRIPTION
We've just released Postman v7.36.1, update your app or get the latest version from our downloads page: https://www.postman.com/downloads/ 🚀 

### Bug Fixes
* Fixed an issue when exporting collections, where the script and variable IDs were included in the collection JSON file. Now they are stripped from the export. Fixes #2906, #4802.
* Fixed an issue where importing invalid swagger was not giving any feedback. Fixes #9315.